### PR TITLE
Upgrade to guzzle v7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "silverstripe/framework": "^4.0",
         "silverstripe/admin": "^1.0",
-        "guzzlehttp/guzzle": "^6.5"
+        "guzzlehttp/guzzle": "^7"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7",

--- a/templates/reoako.ss
+++ b/templates/reoako.ss
@@ -1,8 +1,4 @@
-<link
-    rel="stylesheet"
-    type="text/css"
-    href="/resources/vendor/silverstripe/admin/client/dist/styles/bundle.css"
-/>
+<% require css('silverstripe/admin:client/dist/styles/bundle.css') %>
 
 <div class="modal-content">
     <div class="asset-admin">

--- a/templates/reoako.ss
+++ b/templates/reoako.ss
@@ -1,4 +1,8 @@
-<% require css('silverstripe/admin:client/dist/styles/bundle.css') %>
+<link
+    rel="stylesheet"
+    type="text/css"
+    href="$resourceURL('silverstripe/admin:client/dist/styles/bundle.css')"
+/>
 
 <div class="modal-content">
     <div class="asset-admin">


### PR DESCRIPTION
Updated Guzzle requirement to 7 for compatibility with Silverstripe v7.11

**Warning** that I've had some issues with speed and table styles in the popup not loading properly in the cms (see screenshot). 
I would test in your environment to confirm that nothing breaks (as it might just be on my end and I need to confirm this with other internal devs).
![akopanuku2](https://user-images.githubusercontent.com/343938/196070803-e9e0cce3-ee4a-4065-a783-93919243c436.png)
